### PR TITLE
is this still how it was intended?

### DIFF
--- a/smileys/templatetags/smiley_tags.py
+++ b/smileys/templatetags/smiley_tags.py
@@ -17,12 +17,12 @@ RE_SMILEYS_LIST = [(re.compile(re.escape(smiley[0])), smiley[0], smiley[1])
 
 def replace_smileys(content, autoescape=None):
     esc = autoescape and conditional_escape or (lambda x: x)
-
+    content = esc(content)
     for smiley, name, image in RE_SMILEYS_LIST:
         if smiley.search(content):
             smiley_html = '<img class="%s" src="%s" alt="%s" />' % (
                 SMILEYS_CLASS, os.path.join(SMILEYS_URL, image), name)
-            content = smiley.sub(smiley_html, esc(content))
+            content = smiley.sub(smiley_html, content)
     return mark_safe(content)
 replace_smileys.needs_autoescape = True
 


### PR DESCRIPTION
I ran into the problem that if more then one smileys are displayed the previous smileys get escaped. so i moved the conditional escape to be done only once, before the smileys are replaced. that fixed it, but i am not sure why you escaped the content each time a certain type of smiley was replaced. so please look over it and tell me if this implementation is still as intended.
