### PR TITLE
Fixed emoticon.html for Django 3.0+

### DIFF
--- a/emoticons/templates/emoticons/emoticon.html
+++ b/emoticons/templates/emoticons/emoticon.html
@@ -1,1 +1,1 @@
-{% load staticfiles %}<img class="emoticon emoticon-{{ code }}" src="{% static image %}" alt="{{ name }}" />
+{% load static %}<img class="emoticon emoticon-{{ code }}" src="{% static image %}" alt="{{ name }}" />


### PR DESCRIPTION
The staticfiles template library was removed in Django 3.0, so use static template tag library instead.